### PR TITLE
Remove location of Gradle installation from config

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,3 @@ android.nonTransitiveRClass=true
 
 # set useProductionPublicRepo=true only when you want to use sdk production version from the public artifactory
 useProductionPublicRepo=false
-org.gradle.java.home=/Applications/Android Studio.app/Contents/jbr/Contents/Home


### PR DESCRIPTION
The location of the Gradle installation is specific to the developer's machine and must not be in the project configuration.